### PR TITLE
Allow placement of solumate at a different location

### DIFF
--- a/src/jquery.soulmate.coffee
+++ b/src/jquery.soulmate.coffee
@@ -162,7 +162,11 @@ class Soulmate
     @suggestions      = new SuggestionCollection( renderCallback, selectCallback )  
     @query            = new Query( minQueryLength )  
         
-    @container = $('<ul id="soulmate">').insertAfter(@input)
+    if ($('ul#soulmate').length > 0)
+			@container = $('ul#soulmate')
+		else
+			@container = $('<ul id="soulmate">').insertAfter(@input)
+
       
     @container.delegate('.soulmate-suggestion',
       mouseover: -> that.suggestions.focusElement( this )


### PR DESCRIPTION
Hi,

I had a heavily customized menu bar which also has a search field. ul#soulmate was inheriting all the styles from the menu bar.

This change allows the use of placing ul#soulmate at a different place in dom which avoided css styles from propagating to solumate.

Thanks,
Ajay Kumar G
