### PR TITLE
The timeout for the ajax request can now be configured as a parameter

### DIFF
--- a/spec/compiled/soulmate_spec.js
+++ b/spec/compiled/soulmate_spec.js
@@ -1,6 +1,8 @@
 (function() {
   var Soulmate;
+
   Soulmate = window._test.Soulmate;
+
   describe('Soulmate', function() {
     var renderCallback, selectCallback, soulmate;
     soulmate = renderCallback = selectCallback = null;
@@ -260,7 +262,7 @@
         });
       });
     });
-    return describe('#fetchResults', function() {
+    describe('#fetchResults', function() {
       beforeEach(function() {
         soulmate.query.setValue('job');
         spyOn($, 'ajax');
@@ -277,5 +279,20 @@
         }).toCall(soulmate, 'update');
       });
     });
+    return it("can accept timeout as a parameter", function() {
+      var soulmate2;
+      soulmate2 = new Soulmate($('#search'), {
+        url: 'http://localhost',
+        types: ['type1', 'type2', 'type3'],
+        timeout: 2000,
+        renderCallback: renderCallback,
+        selectCallback: selectCallback,
+        minQueryLength: 2,
+        maxResults: 5
+      });
+      expect(soulmate2.timeout).toNotEqual(500);
+      return expect(soulmate2.timeout).toEqual(2000);
+    });
   });
+
 }).call(this);

--- a/spec/soulmate_spec.coffee
+++ b/spec/soulmate_spec.coffee
@@ -224,4 +224,16 @@ describe 'Soulmate', ->
 
     it 'calls "update" with the responses results on success', ->
       expect( -> $.ajax.mostRecentCall.args[0].success( {results: {}} ) ).toCall( soulmate, 'update' )
-      
+            
+  it "can accept timeout as a parameter", ->
+    soulmate2 = new Soulmate( $('#search'), {
+      url:            'http://localhost'
+      types:          ['type1', 'type2', 'type3']
+      timeout:        2000
+      renderCallback: renderCallback
+      selectCallback: selectCallback
+      minQueryLength: 2
+      maxResults: 5
+    })
+    expect(soulmate2.timeout).toNotEqual 500
+    expect(soulmate2.timeout).toEqual 2000

--- a/src/compiled/jquery.soulmate.js
+++ b/src/compiled/jquery.soulmate.js
@@ -178,19 +178,24 @@
       40: 'down'
     };
     function Soulmate(input, options) {
-      var maxResults, minQueryLength, renderCallback, selectCallback, that, types, url;
+      var maxResults, minQueryLength, renderCallback, selectCallback, that, timeout, types, url;
       this.input = input;
       this.handleKeyup = __bind(this.handleKeyup, this);
       this.handleKeydown = __bind(this.handleKeydown, this);
       that = this;
-      url = options.url, types = options.types, renderCallback = options.renderCallback, selectCallback = options.selectCallback, maxResults = options.maxResults, minQueryLength = options.minQueryLength;
+      url = options.url, types = options.types, renderCallback = options.renderCallback, selectCallback = options.selectCallback, maxResults = options.maxResults, minQueryLength = options.minQueryLength, timeout = options.timeout;
       this.url = url;
       this.types = types;
       this.maxResults = maxResults;
+      this.timeout = timeout || 500;
       this.xhr = null;
       this.suggestions = new SuggestionCollection(renderCallback, selectCallback);
       this.query = new Query(minQueryLength);
-      this.container = $('<ul id="soulmate">').insertAfter(this.input);
+      if ($('ul#soulmate').length > 0) {
+        this.container = $('ul#soulmate');
+      } else {
+        this.container = $('<ul id="soulmate">').insertAfter(this.input);
+      }
       this.container.delegate('.soulmate-suggestion', {
         mouseover: function() {
           return that.suggestions.focusElement(this);
@@ -266,7 +271,7 @@
       return this.xhr = $.ajax({
         url: this.url,
         dataType: 'jsonp',
-        timeout: 500,
+        timeout: this.timeout,
         cache: true,
         data: {
           term: this.query.getValue(),

--- a/src/jquery.soulmate.coffee
+++ b/src/jquery.soulmate.coffee
@@ -151,23 +151,23 @@ class Soulmate
 
     that = this
     
-    {url, types, renderCallback, selectCallback, maxResults, minQueryLength} = options
+    {url, types, renderCallback, selectCallback, maxResults, minQueryLength, timeout} = options
+
     
     @url              = url
     @types            = types
     @maxResults       = maxResults
+    @timeout          = timeout || 500
     
     @xhr              = null
 
     @suggestions      = new SuggestionCollection( renderCallback, selectCallback )  
     @query            = new Query( minQueryLength )  
-        
-    if ($('ul#soulmate').length > 0)
-			@container = $('ul#soulmate')
-		else
-			@container = $('<ul id="soulmate">').insertAfter(@input)
 
-      
+    if ($('ul#soulmate').length > 0)
+      @container = $('ul#soulmate')
+    else
+      @container = $('<ul id="soulmate">').insertAfter(@input)
     @container.delegate('.soulmate-suggestion',
       mouseover: -> that.suggestions.focusElement( this )
       click: (event) -> 
@@ -251,7 +251,7 @@ class Soulmate
     @xhr = $.ajax({
       url: @url
       dataType: 'jsonp'
-      timeout: 500
+      timeout: @timeout
       cache: true
       data: {
         term: @query.getValue()


### PR DESCRIPTION
My autocomplete feature needed more than the 500 ms, so it was failing every time.

All specs are passing, including the one I added.

Also, there are a few incidental changes in the compiled JS, which I think were caused by a newer version of CoffeeScript.
