### PR TITLE
support soulmate stop words

### DIFF
--- a/src/compiled/jquery.soulmate.js
+++ b/src/compiled/jquery.soulmate.js
@@ -31,7 +31,9 @@
     };
 
     Query.prototype.willHaveResults = function() {
-      return this._isValid() && !this._isEmpty();
+      var firstWord;
+      firstWord = this.value.split(' ')[0];
+      return this._isValid() && !this._isEmpty() && !((firstWord === 'vs' || firstWord === 'at' || firstWord === 'the') && this.value.length < firstWord.length + 3);
     };
 
     Query.prototype._isValid = function() {

--- a/src/jquery.soulmate.coffee
+++ b/src/jquery.soulmate.coffee
@@ -20,7 +20,8 @@ class Query
     @emptyValues.push( @value )
     
   willHaveResults: ->
-    @_isValid() && !@_isEmpty()
+    firstWord = @value.split(' ')[0]
+    @_isValid() && !@_isEmpty() && !((firstWord in ['vs', 'at', 'the']) && @value.length < firstWord.length + 3)
     
   _isValid: ->
     @value.length >= @minLength


### PR DESCRIPTION
Soulmate treats "vs", "at", and "the" as stop words, removing them from the combinations in redis.

Right now if one searches for "The Dark Knight" soulmate.js will stop searching when "the" returns no results. A search for "dark knight" will return the correct results.

This small patch makes soulmate.js essentially ignore stop words at the start of the search query.

Signed-off-by: Marc MacLeod marbemac@gmail.com
