### PR TITLE
Update README to point to default soulmate search path

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -40,7 +40,7 @@ First, setup an instance of [soulmate](https://github.com/seatgeek/soulmate). Th
 
     // Make the input field autosuggest-y.
     $('#search-input').soulmate({
-      url:            'http://soulmate.YOUR-DOMAIN.com',
+      url:            'http://soulmate.YOUR-DOMAIN.com/search',
       types:          ['type1', 'type2', 'type3', 'type4'],
       renderCallback: render,
       selectCallback: select,


### PR DESCRIPTION
When mounting the soulmate engine into a Rails app, at '/sm', the README
indicated that this is the URL we should query.  This is incorrect for the gem
itself, which expects you to query '/sm/search'.  The demo app works because they
have obviously mounted the engine differently (w/o 'search'). 
